### PR TITLE
add SetupToolbarCustomization call

### DIFF
--- a/CustomNavigationBarSample.Android/Renderers/CustomNavigationPageRenderer.cs
+++ b/CustomNavigationBarSample.Android/Renderers/CustomNavigationPageRenderer.cs
@@ -301,7 +301,7 @@ namespace CustomNavigationBarSample.Droid.Renderers
 
                 lastPage.PropertyChanged += LastPage_PropertyChanged;
 
-
+                SetupToolbarCustomization(lastPage);
             }
         }
 


### PR DESCRIPTION
In Formatted Title and Image Title, characters and image disappear when the screen orientation is changed.
I tested it Android version 6.0.
At the beginning I uncommented at line 54.
54:    // SetupToolbarCustomization(Element?.Navigation?.NavigationStack?.Last());
But sometimes characters and image disappeared. I think it needs SetupToolbarCustomization call at bottom of OnViewAdded.